### PR TITLE
Use `core.ref.` for referenced translations

### DIFF
--- a/resources/locale/en.yml
+++ b/resources/locale/en.yml
@@ -1,8 +1,8 @@
 flarum-ext-welcomebox:
   forum:
     wback: Welcome back,
-    npost: => core.forum.user.posts_link
-    discussion: => core.forum.user.discussions_link
+    npost: => core.ref.posts
+    discussion: => core.ref.discussions
     welcomeguest: Welcome Guest
     notregistered: You are currently not registered to this forum.
   admin:


### PR DESCRIPTION
I don't think that translations for specific contexts should be referenced directly. It is better to reference generic translations from `core.ref.` - it should be more reliable and slightly more efficient.