### PR TITLE
Using references for terms

### DIFF
--- a/resources/locale/en.yml
+++ b/resources/locale/en.yml
@@ -5,7 +5,7 @@ flarum-ext-welcomebox:
     discussion: => core.ref.discussions
     welcomeguest: Welcome Guest
     notregistered: You are currently not registered to this forum.
-    goToProfile: Profile
-    SettingsLink: Settings
+    goToProfile: => core.ref.profile_button
+    SettingsLink: => core.ref.settings
   admin:
     enablepostbox: Enable Welcome Box for guest


### PR DESCRIPTION
This change is allow to use `core.ref.profile_button`and `core.ref.settings` for terms. This also helps translators.