### PR TITLE
Update forum.less

### DIFF
--- a/resources/less/forum.less
+++ b/resources/less/forum.less
@@ -211,10 +211,4 @@ p.guestdesc {
 }
 body when (@config-dark-mode = true) {
 .textinfo {color:#fff}
-.TagLabel.colored .TagLabel-text {
-color: #fff !important;
-}
-.Button--primary {
-color: #fff;
-}
 }


### PR DESCRIPTION
I have removed some CSS styles that are not related to the flarum-ext-welcomebox. But I have used them to change other elements that I want to change. But I do not think it is not a good idea to add those changes through this extension. Those styles will change Tag text color in dark mode and start discussion button texts to white.