### PR TITLE
Changing box color in Dark mode

### DIFF
--- a/resources/less/forum.less
+++ b/resources/less/forum.less
@@ -210,5 +210,10 @@ p.guestdesc {
   margin-top: 8px;
 }
 body when (@config-dark-mode = true) {
-.textinfo {color:#fff}
+.textinfo {
+  color:#fff
+  }
+  .backgrwb {
+  background: fade(@primary-color, 10%) !important;
+  }
 }


### PR DESCRIPTION
This tweak will change Welcome Box background color if someone turned on Dark mode. Otherwise, Welcome box color will @primarybgww: linear-gradient(0deg, rgba(252,252,252,1) 0%, rgba(255,255,255,0) 100%);. Then no one can see the text because already we have changed dark mode text color to white. If you think the color should be the same in Day mode color also.